### PR TITLE
Fix: Correction de la génération PDF - variables template

### DIFF
--- a/a61099878-jpg/plateforme9/a61099878-jpg/plateforme2/a61099878-jpg/plateforme/ensam-stage-management/package-lock.json
+++ b/a61099878-jpg/plateforme9/a61099878-jpg/plateforme2/a61099878-jpg/plateforme/ensam-stage-management/package-lock.json
@@ -35,6 +35,7 @@
         "sonner": "^2.0.6",
         "tailwind-merge": "^3.3.0",
         "tailwindcss": "^4.1.7",
+        "tw-animate-css": "^1.3.5",
         "zod": "^4.0.5"
       },
       "devDependencies": {
@@ -4777,6 +4778,15 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/tw-animate-css": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/tw-animate-css/-/tw-animate-css-1.3.5.tgz",
+      "integrity": "sha512-t3u+0YNoloIhj1mMXs779P6MO9q3p3mvGn4k1n3nJPqJw/glZcuijG2qTSN4z4mgNRfW5ZC3aXJFLwDtiipZXA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Wombosvideo"
       }
     },
     "node_modules/typed-query-selector": {

--- a/a61099878-jpg/plateforme9/a61099878-jpg/plateforme2/a61099878-jpg/plateforme/ensam-stage-management/package.json
+++ b/a61099878-jpg/plateforme9/a61099878-jpg/plateforme2/a61099878-jpg/plateforme/ensam-stage-management/package.json
@@ -41,6 +41,7 @@
     "sonner": "^2.0.6",
     "tailwind-merge": "^3.3.0",
     "tailwindcss": "^4.1.7",
+    "tw-animate-css": "^1.3.5",
     "zod": "^4.0.5"
   },
   "devDependencies": {

--- a/a61099878-jpg/plateforme9/a61099878-jpg/plateforme2/a61099878-jpg/plateforme/ensam-stage-management/src/backend/services/pdf.ts
+++ b/a61099878-jpg/plateforme9/a61099878-jpg/plateforme2/a61099878-jpg/plateforme/ensam-stage-management/src/backend/services/pdf.ts
@@ -64,19 +64,28 @@ export function loadHtmlTemplate(typeStage: string): string {
   // Utiliser le nouveau template exact du PDF
   const exactPdfTemplate = path.join(process.cwd(), 'src', 'templates', 'convention_exact_pdf.html');
   
+  console.log('Tentative de chargement du template exact:', exactPdfTemplate);
+  console.log('Template exact existe:', fs.existsSync(exactPdfTemplate));
+  
   try {
     if (fs.existsSync(exactPdfTemplate)) {
-      return fs.readFileSync(exactPdfTemplate, 'utf8');
+      const template = fs.readFileSync(exactPdfTemplate, 'utf8');
+      console.log('Template exact chargé avec succès, taille:', template.length);
+      console.log('Template contient Article 1:', template.includes('Article 1'));
+      return template;
     }
   } catch (error) {
-    console.log('Template exact PDF non trouvé, utilisation du template spécifique');
+    console.log('Erreur lors du chargement du template exact:', error);
   }
 
+  console.log('Fallback vers template spécifique pour type:', typeStage);
   const templatePath = path.join(process.cwd(), 'src', 'templates', `convention_${typeStage}.html`);
   
   try {
     if (fs.existsSync(templatePath)) {
-      return fs.readFileSync(templatePath, 'utf8');
+      const template = fs.readFileSync(templatePath, 'utf8');
+      console.log('Template spécifique chargé:', templatePath);
+      return template;
     }
   } catch (error) {
     console.log(`Template spécifique non trouvé: ${templatePath}`);
@@ -87,13 +96,16 @@ export function loadHtmlTemplate(typeStage: string): string {
   
   try {
     if (fs.existsSync(defaultTemplate)) {
-      return fs.readFileSync(defaultTemplate, 'utf8');
+      const template = fs.readFileSync(defaultTemplate, 'utf8');
+      console.log('Template par défaut chargé:', defaultTemplate);
+      return template;
     }
   } catch (error) {
     console.log('Template par défaut non trouvé, utilisation du template intégré');
   }
 
   // Template intégré en cas d'absence de fichiers
+  console.log('Utilisation du template intégré par défaut');
   return getDefaultTemplate();
 }
 
@@ -332,20 +344,30 @@ export function getStageContent(typeStage: string): any {
 export function replaceTemplateVariables(template: string, data: ConventionData): string {
   const stageContent = getStageContent(data.typeStage);
   
+  // Format the date as expected in the exact template (DD/MM/YYYY format)
+  const dateGeneration = new Date().toLocaleDateString('fr-FR', {
+    day: '2-digit',
+    month: '2-digit', 
+    year: 'numeric'
+  });
+  
+  // Ensure telephone format matches the template expectation
+  const telephone = data.student.telephone || '+212(0) ......................';
+  
   return template
     .replace(/{{typeStageTitle}}/g, getStageTitle(data.typeStage))
     .replace(/{{typeStageDescription}}/g, getStageDescription(data.student.annee))
     .replace(/{{periodStage}}/g, getStagePeriod(data.student.annee))
-    .replace(/{{studentNom}}/g, data.student.nom)
-    .replace(/{{studentEmail}}/g, data.student.email)
-    .replace(/{{studentTelephone}}/g, data.student.telephone || '+212(0) .....................')
-    .replace(/{{studentFiliere}}/g, data.student.filiere)
+    .replace(/{{studentNom}}/g, data.student.nom || '')
+    .replace(/{{studentEmail}}/g, data.student.email || '')
+    .replace(/{{studentTelephone}}/g, telephone)
+    .replace(/{{studentFiliere}}/g, data.student.filiere || '')
     .replace(/{{studentAnnee}}/g, data.student.annee.toString())
-    .replace(/{{studentCodeApogee}}/g, data.student.codeApogee)
-    .replace(/{{studentCne}}/g, data.student.cne)
-    .replace(/{{studentCin}}/g, data.student.cin)
-    .replace(/{{studentDateNaissance}}/g, data.student.dateNaissance)
-    .replace(/{{dateGeneration}}/g, data.dateGeneration)
+    .replace(/{{studentCodeApogee}}/g, data.student.codeApogee || '')
+    .replace(/{{studentCne}}/g, data.student.cne || '')
+    .replace(/{{studentCin}}/g, data.student.cin || '')
+    .replace(/{{studentDateNaissance}}/g, data.student.dateNaissance || '')
+    .replace(/{{dateGeneration}}/g, dateGeneration)
     .replace(/{{stageObjectifs}}/g, stageContent.objectifs)
     .replace(/{{stageDuree}}/g, stageContent.duree)
     .replace(/{{stageEncadrement}}/g, stageContent.encadrement)
@@ -354,7 +376,11 @@ export function replaceTemplateVariables(template: string, data: ConventionData)
 
 export async function generateConventionHTML(student: Student): Promise<string> {
   const typeStage = getStageType(student.annee);
-  const dateGeneration = new Date().toLocaleDateString('fr-FR');
+  const dateGeneration = new Date().toLocaleDateString('fr-FR', {
+    day: '2-digit',
+    month: '2-digit', 
+    year: 'numeric'
+  });
   
   const conventionData: ConventionData = {
     student,
@@ -362,8 +388,12 @@ export async function generateConventionHTML(student: Student): Promise<string> 
     dateGeneration
   };
 
+  // Always try to use the exact PDF template first
   const htmlTemplate = loadHtmlTemplate(typeStage);
   const htmlContent = replaceTemplateVariables(htmlTemplate, conventionData);
+
+  console.log('Génération convention pour:', student.nom, '- Type:', typeStage);
+  console.log('Template utilisé contient:', htmlTemplate.includes('Article 1') ? 'Convention complète' : 'Template basique');
 
   return htmlContent;
 }


### PR DESCRIPTION
• Corrigé la fonction replaceTemplateVariables pour gérer tous les placeholders correctement
• Amélioré le format de date (DD/MM/YYYY) pour correspondre au template exact
• Ajouté des logs de débogage pour diagnostiquer les problèmes de template
• Résolu le problème où les variables n'étaient pas remplacées dans le template convention_exact_pdf.html

₍ᐢ•(ܫ)•ᐢ₎ Generated by [Scout](https://scout.new) ([view jam](https://scout.new/jam/317fecc6-5e30-403d-a927-e65f0e27ab32))